### PR TITLE
add repo info and issues info

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
     "name": "utf7",
     "version": "1.0.2",
     "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
+    "repository" : {
+        "type": "git",
+        "url": "https://github.com/kkaefer/utf7"
+    },
+    "bugs": {
+        "url": "https://github.com/kkaefer/utf7/issues"
+    },
     "author": "Konstantin Käfer <kkaefer@gmail.com>",
     "licenses": [ { "type": "BSD" } ],
 


### PR DESCRIPTION
I search utf7 from npmjs: https://www.npmjs.com/package/utf7 but I didn't find the link to this repo. I think you should add repo info for npmjs.com so everyone can see your source code.