### PR TITLE
Assume process version is set to 6.0.0 if missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "utf7",
-    "version": "1.0.2",
-    "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
-    "author": "Konstantin Käfer <kkaefer@gmail.com>",
-    "licenses": [ { "type": "BSD" } ],
-
-    "main": "./utf7",
-
-    "dependencies": {
-        "semver": "~5.3.0"
-    },
-
-    "devDependencies": {
-        "tape": "~4.6.0"
-    },
-
-    "scripts": {
-        "test": "tape test/*.js"
+  "name": "utf7",
+  "version": "1.0.3",
+  "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
+  "author": "Konstantin Käfer <kkaefer@gmail.com>",
+  "licenses": [
+    {
+      "type": "BSD"
     }
+  ],
+  "main": "./utf7",
+  "dependencies": {
+    "semver": "~5.3.0"
+  },
+  "devDependencies": {
+    "tape": "~4.6.0"
+  },
+  "scripts": {
+    "test": "tape test/*.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utf7",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
   "author": "Konstantin Käfer <kkaefer@gmail.com>",
   "licenses": [

--- a/utf7.js
+++ b/utf7.js
@@ -27,7 +27,7 @@ function encode(str) {
     return b.toString('base64').replace(/=+$/, '');
 }
 
-if (semver.gte(process.version, '6.0.0')) {
+if (semver.gte(process.version || '6.0.0', '6.0.0')) {
     function allocateBase64Buffer(str) {
         return Buffer.from(str, 'base64');
     }

--- a/utf7.js
+++ b/utf7.js
@@ -1,7 +1,7 @@
 var Buffer = require('buffer').Buffer;
 var semver = require('semver');
 
-if (semver.gte(process.version, '6.0.0')) {
+if (semver.gte(process.version || '6.0.0', '6.0.0')) {
     function allocateAsciiBuffer(length) {
         return Buffer.alloc(length, 'ascii');
     }


### PR DESCRIPTION
In some environments, such as browserify, process.version can be empty in which case the module will fail Invalid Version: exception. The proposed change ensures that process.version is interpreted as 6.0.0 if missing.