### PR TITLE
Fix package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
     "version": "1.0.2",
     "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
     "author": "Konstantin Käfer <kkaefer@gmail.com>",
-    "licenses": [ { "type": "BSD" } ],
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/kkaefer/utf7"
+    },
 
     "main": "./utf7",
 


### PR DESCRIPTION
Changes the following:

1. Updates license field to use SPDX syntax; other forms are [deprecated](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license), and the array syntax in particular is no longer understood by the npm frontend.
2. Changes the license in package.json to match the LICENSE file in the repository (MIT rather than "unspecified BSD").
3. Adds the URL of the repository.