### PR TITLE
Update the semver package version to solve a vulnerability issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,18 +3,18 @@
     "version": "1.0.2",
     "description": "Converts text to and from UTF-7 (RFC 2152 and IMAP)",
     "author": "Konstantin Käfer <kkaefer@gmail.com>",
-    "licenses": [ { "type": "BSD" } ],
-
+    "licenses": [
+        {
+            "type": "BSD"
+        }
+    ],
     "main": "./utf7",
-
     "dependencies": {
-        "semver": "~5.3.0"
+        "semver": "^7.7.3"
     },
-
     "devDependencies": {
         "tape": "~4.6.0"
     },
-
     "scripts": {
         "test": "tape test/*.js"
     }


### PR DESCRIPTION
This package is used by some great software like http://github.com/node-red/node-red-nodes/ and is causing some break when try to install  the deps with `npm ci` that is related with a vulnerability issue:

```sh
18:17 $ npm audit 
# npm audit report

semver  <5.7.2
Severity: high
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install semver@5.7.2, which is outside the stated dependency range
node_modules/semver

1 high severity vulnerability

To address all issues, run:
  npm audit fix --force
```

Would be great an update to the latest version so I did it and now don't have the warning about the vulnerability:

```sh
✔ /tmp/imap [update-semver-version-to-fix-vuln-issue L|…2] 
18:18 $ npm install

changed 1 package, and audited 116 packages in 608ms

72 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
After the update, I run the tests and everything was ok:

```sh
✔ /tmp/imap [update-semver-version-to-fix-vuln-issue L|…2] 
18:18 $ node test/utf7-imap.js 
TAP version 13
# test conversion from utf8 to utf7
ok 1 should be equal
ok 2 should be equal
ok 3 should be equal
ok 4 should be equal
ok 5 should be equal
ok 6 should be equal
ok 7 should be equal
ok 8 should be equal
ok 9 should be equal
# test conversion from utf7 to utf8
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
ok 13 should be equal
ok 14 should be equal
ok 15 should be equal
ok 16 should be equal
ok 17 should be equal
ok 18 should be equal

1..18
# tests 18
# pass  18

# ok

✔ /tmp/imap [update-semver-version-to-fix-vuln-issue L|…2] 
18:19 $ node test/utf7-rfc2152.js 
TAP version 13
# test conversion from utf8 to utf7
ok 1 should be equal
ok 2 should be equal
ok 3 should be equal
ok 4 should be equal
ok 5 should be equal
ok 6 should be equal
ok 7 should be equal
ok 8 should be equal
ok 9 should be equal
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
ok 13 should be equal
ok 14 should be equal
ok 15 should be equal
ok 16 should be equal
ok 17 should be equal
ok 18 should be equal
ok 19 should be equal
ok 20 should be equal
# test conversion from utf7 to utf8
ok 21 should be equal
ok 22 should be equal
ok 23 should be equal
ok 24 should be equal
ok 25 should be equal
ok 26 should be equal
ok 27 should be equal
ok 28 should be equal
ok 29 should be equal
ok 30 should be equal
ok 31 should be equal
ok 32 should be equal
ok 33 should be equal
ok 34 should be equal
ok 35 should be equal
ok 36 should be equal
ok 37 should be equal
ok 38 should be equal
ok 39 should be equal
ok 40 should be equal
ok 41 should be equal
ok 42 should be equal

1..42
# tests 42
# pass  42

# ok
```